### PR TITLE
fixing apparent typo in addition of sample sheet to TSRexploreR

### DIFF
--- a/R/bam_processing.R
+++ b/R/bam_processing.R
@@ -119,7 +119,7 @@ import_bams <- function(
 
   ## Add GRanges and sample sheet to tsr explorer object.
   experiment@experiment$TSSs <- bams
-  experiment@meta_data@sample_sheet <- sample_sheet
+  experiment@meta_data$sample_sheet <- sample_sheet
 
   return(experiment)
 }


### PR DESCRIPTION
Replaced second @ with $ at the indicated location for proper slot access.