### PR TITLE
Changing is.readable to is.character

### DIFF
--- a/R/TSRexplore.R
+++ b/R/TSRexplore.R
@@ -78,7 +78,7 @@ tsr_explorer <- function(
   assert_that(
     is.null(sample_sheet) ||
     is.data.frame(sample_sheet) ||
-    is.readable(sample_sheet)
+    is.character(sample_sheet)
   )
 
   ## Prepare sample sheet.

--- a/R/association.R
+++ b/R/association.R
@@ -36,7 +36,7 @@ merge_samples <- function(
   )
   assert_that(
     is.null(sample_sheet) ||
-    (is.readable(sample_sheet) | is.data.frame(sample_sheet))
+    (is.character(sample_sheet) | is.data.frame(sample_sheet))
   )
   assert_that(is.null(merge_group) || is.string(merge_group))
   assert_that(

--- a/R/data_import.R
+++ b/R/data_import.R
@@ -44,7 +44,7 @@ tss_import <- function(
   assert_that(is(experiment, "tsr_explorer"))
   assert_that(
     is.null(sample_sheet) ||
-    (is.readable(sample_sheet) | is.data.frame(sample_sheet))
+    (is.character(sample_sheet) | is.data.frame(sample_sheet))
   )
   file_type <- match.arg(
     str_to_lower(file_type),
@@ -226,7 +226,7 @@ tsr_import <- function(
   assert_that(is(experiment, "tsr_explorer"))
   assert_that(
     is.null(sample_sheet) ||
-    (is.readable(sample_sheet) | is.data.frame(sample_sheet))
+    (is.character(sample_sheet) | is.data.frame(sample_sheet))
   )
   file_type <- match.arg(
     str_to_lower(file_type),


### PR DESCRIPTION
Returns an error instead of a logical when testing, which breaks input checks.