### PR TITLE
fixes due to numeric overflow for long shift score calculations

### DIFF
--- a/R/tss_shifting.R
+++ b/R/tss_shifting.R
@@ -172,10 +172,15 @@ ShiftScores <- function(
   )
 
   ## Add the coordinates back to the shifting score.
-  outdf <- out %>%
-    t %>%
-    as_tibble(.name_repair="unique") %>%
-    dplyr::rename(shift_score=1, pval=2)
+  
+  ## altered to avoid warning message on naming
+  out <- t(out)
+  colnames(out) <- c("shift_score", "pval")
+  outdf <- as_tibble(out)
+  # outdf <- out %>%
+  #   t %>%
+  #   as_tibble(.name_repair="unique") %>%
+  #   dplyr::rename(shift_score=1, pval=2)
 
   outdf <- dat %>%
      dplyr::distinct(fhash) %>%

--- a/src/shiftscore.cpp
+++ b/src/shiftscore.cpp
@@ -18,8 +18,10 @@ double ShiftScoreFast(arma::vec x, arma::vec y, int k, int xn, int yn, arma::uve
 arma::vec ShiftScore(arma::sp_mat x, arma::sp_mat y, int calcP, int nresamp){
   // Inputs are sparse vectors of the same length with counts, unnormalized
 
-  int xn = accu(x);
-  int yn = accu(y);
+  double xn = accu(x);
+  double yn = accu(y);
+  // arma::sp_mat _x = x;
+  // arma::sp_mat _y = y;
   
   x /= xn;
   y /= yn;
@@ -36,7 +38,7 @@ arma::vec ShiftScore(arma::sp_mat x, arma::sp_mat y, int calcP, int nresamp){
   
   if(calcP){
     double pp = 0.0;
-    arma::sp_mat pxy = (xn*x + yn*y) / (xn + yn);
+    arma::sp_mat pxy = (x*xn + y*yn) / (xn + yn);
     arma::vec dense_probs = arma::nonzeros(pxy);
     arma::uvec pos_pxy = arma::find(pxy);
 


### PR DESCRIPTION
This should fix Gabe's difficulty (runs correctly locally). I would note that when I run, I get the following:

```
Joining, by = c("fhash", "sample_indicator")
Warning messages:
1: In .local(x, row.names, optional, ...) : Arguments in '...' ignored
2: In ShiftScores(overlap, baseline_level = sample_1["TSS"], nresamp = n_resamples,  :
  Some sequences have fewer than nthresh scores for at least one sample. 
            These are ignored and returned as NA.
```

The second warning is to be expected. I'm not sure of the origin of the first. It doesn't have to do with the calculation but likely some tibble conversion or join somewhere else. It would probably be good to make it go away.

Let me know if the scores themselves look odd. The previous issue is that some histograms had lots/large values in them so normalizing to get a vector of probabilites ran into trouble (dividing integers by an integer and then summing can be troublesome). Essentially all I did was convert to double precision. It's possible (though I think unlikely) that simple cases could have a bit less precision in later decimals.