### PR TITLE
remove unchanged genes when exporting DEGs for enrichment

### DIFF
--- a/R/diff_exp_plots.R
+++ b/R/diff_exp_plots.R
@@ -135,6 +135,8 @@ plot_volcano <- function(
 #' @param de_comparisons The DE comparisons to plot
 #' @param log2fc_cutoff Log2FC cutoff value
 #' @param fdr_cutoff FDR cutoff value
+#' @param keep_unchanged If TRUE genes that are labelled unchanged will
+#'   be kept.
 #'
 #' @rdname export_for_enrichment-function
 #'
@@ -145,7 +147,8 @@ export_for_enrichment <- function(
   data_type=c("tss", "tsr"),
   de_comparisons="all",
   log2fc_cutoff=1,
-  fdr_cutoff=0.05
+  fdr_cutoff=0.05,
+  keep_unchanged=FALSE
 ) {
 
   ## Input checks.
@@ -161,9 +164,17 @@ export_for_enrichment <- function(
 
   ## Mark de status.
   .de_status(de_samples, log2fc_cutoff, fdr_cutoff)
-  de_samples[, de_status := factor(
-    de_status, levels=c("up", "unchanged", "down")
-  )]
+
+  if (keep_unchanged) {
+    de_samples[, de_status := factor(
+      de_status, levels=c("up", "unchanged", "down")
+    )]
+  } else {
+    de_samples <- de_samples[de_status != "unchanged"]
+    de_samples[, de_status := factor(
+      de_status, levels=c("up", "down")
+    )]
+  }
   
   return(de_samples)
 }

--- a/man/export_for_enrichment-function.Rd
+++ b/man/export_for_enrichment-function.Rd
@@ -9,7 +9,8 @@ export_for_enrichment(
   data_type = c("tss", "tsr"),
   de_comparisons = "all",
   log2fc_cutoff = 1,
-  fdr_cutoff = 0.05
+  fdr_cutoff = 0.05,
+  keep_unchanged = FALSE
 )
 }
 \arguments{
@@ -22,6 +23,9 @@ export_for_enrichment(
 \item{log2fc_cutoff}{Log2FC cutoff value}
 
 \item{fdr_cutoff}{FDR cutoff value}
+
+\item{keep_unchanged}{If TRUE genes that are labelled unchanged will
+be kept.}
 }
 \description{
 Export DEGs for use in clusterProfiler term enrichment.


### PR DESCRIPTION
Unchanged genes are no longer included by default when exporting DEGs for enrichment analysis.

addresses #61 