### PR TITLE
TSS annotation and genome related unit tests. BSgenome import bug fix.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -57,7 +57,9 @@ Suggests:
     clusterProfiler,
     TSRchitect,
     org.Sc.sgd.db,
-    testthat
+    testthat,
+    TxDb.Scerevisiae.UCSC.sacCer3.sgdGene,
+    BSgenome.Scerevisiae.UCSC.sacCer3
 RoxygenNote: 7.1.1
 Collate: 
     'RcppExports.R'

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -27,6 +27,7 @@ r-ggally \
 r-cowplot \
 r-rcpp \
 r-assertthat \
+r-testthat \
 bioconductor-apeglm \
 bioconductor-genomicranges \
 bioconductor-genomicfeatures \
@@ -46,6 +47,8 @@ bioconductor-biocgenerics \
 bioconductor-plyranges \
 bioconductor-pcatools \
 bioconductor-GenomeInfoDb
+bioconductor-bsgenome.scerevisiae.ucsc.saccer3 \
+bioconductor-txdb.scerevisiae.ucsc.saccer3.sgdgene
 
 conda activate TSRexploreR
 ```

--- a/R/TSRexplore.R
+++ b/R/TSRexplore.R
@@ -188,7 +188,7 @@ tsr_explorer <- function(
 
   ## If assembly is a fasta file make sure it's indexed.
   if (
-    assembly_type == "file" &
+    assembly_type == "file" &&
     !file.exists(str_c(assembly, ".fai"))
   ) {
     indexFa(assembly)

--- a/tests/testthat/test-TSS_processing.R
+++ b/tests/testthat/test-TSS_processing.R
@@ -48,3 +48,45 @@ test_that("TSS Normalization", {
       "FHASH", "normalized_score", "score"
     ))
 })
+
+test_that("TSS annotation", {
+  annotation <- system.file("extdata", "S288C_Annotation.gtf", package="TSRexploreR")
+  tsre <- tsr_explorer(TSSs["S288C_WT_1"], genome_annotation=annotation) %>%
+    format_counts(data_type="tss")
+
+  expected_columns <- c(
+    "seqnames", "start", "end", "width", "strand", "score", "FHASH", 
+    "annotation", "geneChr", "geneStart", "geneEnd", "geneLength", 
+    "geneStrand", "geneId", "distanceToTSS", "simple_annotations"
+  )
+
+  ## Annotate based on gene.
+  gene_columns <- c(
+    "seqnames", "start", "end", "width", "strand", "score", "FHASH",
+    "annotation", "geneChr", "geneStart", "geneEnd", "geneLength",
+    "geneStrand", "geneId", "distanceToTSS", "simple_annotations"
+  )
+  gene_anno <- annotate_features(tsre, data_type="tss", feature_type="gene")
+  gene_anno@counts$TSSs$raw %>%
+    expect_type("list") %>%
+    expect_length(1) %>%
+    expect_named("S288C_WT_1")
+  gene_anno@counts$TSSs$raw$S288C_WT_1 %>%
+    expect_s3_class("data.table") %>%
+    expect_named(gene_columns)
+
+  ## Annotate based on transcript.
+  tx_columns <- c(
+    "seqnames", "start", "end", "width", "strand", "score", "FHASH", 
+    "annotation", "geneChr", "geneStart", "geneEnd", "geneLength", 
+    "geneStrand", "geneId", "transcriptId", "distanceToTSS", "simple_annotations"
+  )
+  tx_anno <- annotate_features(tsre, data_type="tss", feature_type="transcript")
+  tx_anno@counts$TSSs$raw %>%
+    expect_type("list") %>%
+    expect_length(1) %>%
+    expect_named("S288C_WT_1")
+  tx_anno@counts$TSSs$raw$S288C_WT_1 %>%
+    expect_s3_class("data.table") %>%
+    expect_named(tx_columns)
+})

--- a/tests/testthat/test-genome.R
+++ b/tests/testthat/test-genome.R
@@ -1,0 +1,26 @@
+context("Genome Annotation and Assembly")
+
+library("TxDb.Scerevisiae.UCSC.sacCer3.sgdGene")
+library("BSgenome.Scerevisiae.UCSC.sacCer3")
+assembly <- system.file("extdata", "S288C_Assembly.fasta", package="TSRexploreR")
+annotation <- system.file("extdata", "S288C_Annotation.gtf", package="TSRexploreR")
+
+test_that("Import of assemblies", {
+  ## FASTA assembly.
+  fasta_tsre <- tsr_explorer(genome_assembly=assembly)
+  expect_s4_class(fasta_tsre@meta_data$genome_assembly, "FaFile")
+
+  ## BSgenome assembly.
+  bsgenome_tsre <- tsr_explorer(genome_assembly=BSgenome.Scerevisiae.UCSC.sacCer3)
+  expect_s4_class(bsgenome_tsre@meta_data$genome_assembly, "BSgenome")
+})
+
+test_that("Import of annotations", {
+  ## GTF annotation.
+  gtf_tsre <- tsr_explorer(genome_annotation=annotation)
+  expect_s4_class(gtf_tsre@meta_data$genome_annotation, "TxDb")
+
+  ## TxDb annotation.
+  txdb_tsre <- tsr_explorer(genome_annotation=TxDb.Scerevisiae.UCSC.sacCer3.sgdGene)
+  expect_s4_class(txdb_tsre@meta_data$genome_annotation, "TxDb")
+})


### PR DESCRIPTION
Added unit tests for:
- TSS annotation based on gene or transcript.
- Importing genome assembly from FASTA or BSgenome.
- Importing genome annotation from GTF or TxDb.

Added BSgenome.Scerevisiae.UCSC.sacCer3 and TxDb.Scerevisiae.UCSC.sacCer3.sgdGene to suggests for unit testing.

Fixed a bug where when importing from BSgenome.