### PR TITLE
changes to tss_clustering

### DIFF
--- a/man/dot-aggr_scores.Rd
+++ b/man/dot-aggr_scores.Rd
@@ -4,7 +4,7 @@
 \alias{.aggr_scores}
 \title{Aggregate Scores}
 \usage{
-.aggr_scores(granges, maxdist)
+.aggr_scores(granges, maxdist, maxwidth)
 }
 \arguments{
 \item{granges}{GRanges}

--- a/man/tss_clustering-function.Rd
+++ b/man/tss_clustering-function.Rd
@@ -8,7 +8,8 @@ tss_clustering(
   experiment,
   samples = "all",
   threshold = NULL,
-  max_distance = 25
+  max_distance = 25,
+  max_width = NULL
 )
 }
 \arguments{
@@ -19,6 +20,8 @@ tss_clustering(
 \item{threshold}{TSSs or TSRs with a score below this value will be discarded.}
 
 \item{max_distance}{Maximum distance between TSSs that can be clustered}
+
+\item{max_width}{Maximum width of TSR allowed.}
 }
 \value{
 TSRexploreR object with TSRs


### PR DESCRIPTION
Made a few changes to TSS clustering.
- Sped up clustering and made it more memory efficient by switching to data.table `foverlaps`.
- Added an argument to specify the maximum TSR width to return.
- Fixed a bug where the number of unique TSSs per TSR was incorrect.