### PR TITLE
modified behavior of apply_threshold

### DIFF
--- a/man/apply_threshold.Rd
+++ b/man/apply_threshold.Rd
@@ -4,17 +4,16 @@
 \alias{apply_threshold}
 \title{Apply a threshold to TSSs or TSRs}
 \usage{
-apply_threshold(
-  experiment,
-  threshold,
-  data_type = c("tss", "tsr"),
-  use_normalized = FALSE
-)
+apply_threshold(experiment, threshold, n_samples = 1, use_normalized = FALSE)
 }
 \arguments{
 \item{experiment}{TSRexploreR object.}
 
 \item{threshold}{TSSs or TSRs with a score below this value will be discarded.}
+
+\item{n_samples}{Number of samples threshold must be reached to keep TSS.
+By default set to 1 sample. A NULL value will result in all samples being
+required to have read counts above threshold.}
 
 \item{use_normalized}{Whether to use the normalized (TRUE) or raw (FALSE) counts.}
 }

--- a/vignettes/STANDARD_ANALYSIS.Rmd
+++ b/vignettes/STANDARD_ANALYSIS.Rmd
@@ -90,7 +90,9 @@ plot_threshold_exploration(threshold_data, ncol=3, point_size=0.5) +
   scale_color_viridis_c() 
 ```
 
-Looking at the plot, a threshold of three or more reads is a sensible choice: there is a precipitous drop in detected features for a comparatively low gain in promoter-proximal TSS fraction at higher thresholds.
+Looking at the plot, a threshold of three or more reads is a sensible choice:
+  there is a precipitous drop in detected features for a comparatively low gain in promoter-proximal TSS fraction at higher thresholds.
+TSSs will be discarded if no samples have at least 1 TSS at that position with three or more reads.
 
 ```{r message=FALSE}
 exp <- apply_threshold(exp, threshold=3)
@@ -211,7 +213,7 @@ To identify TSRs, TSRexploreR uses a distance clustering method. This approach g
 However, if you have called TSRs using other methods (e.g. Paraclu or RECLU), they can be imported directly.
 
 ```{r message=FALSE}
-exp <- tss_clustering(exp, threshold=3, max_distance=25)
+exp <- tss_clustering(exp, max_distance=25)
 ```
 
 ### Associating TSSs with TSRs


### PR DESCRIPTION
Added argument `n_samples` to `apply_threshold` to allow specification of number of samples that must meet threshold to keep TSS in all samples.

Also partially addresses #67 