### PR TITLE
unit tests for sequence related functions, and big fix for tss_sequences

### DIFF
--- a/R/motif.R
+++ b/R/motif.R
@@ -130,7 +130,7 @@ tss_sequences <- function(
 
   ## Order samples if required.
   if (!all(samples == "all")) {
-    seqs[, sample := factor(seqs, levels=samples)]
+    seqs[, sample := factor(sample, levels=samples)]
   }
   
   ## Generate and return DataFrame.

--- a/tests/testthat/test-sequence_related.R
+++ b/tests/testthat/test-sequence_related.R
@@ -1,0 +1,37 @@
+context("Sequence Retrieval Functions")
+source("setup.R")
+
+test_that("TSS sequence colormap and sequence logo", {
+  ## Sequence DataFrame.
+  seqs <- tsr_explorer(TSSs["S288C_WT_1"], genome_assembly=assembly) %>%
+    format_counts(data_type="tss") %>%
+    tss_sequences
+  seqs %>%
+    expect_s4_class("DataFrame") %>%
+    expect_named(c("sample", "FHASH", "plot_order", "tss", "sequence", "score"))
+
+  ## Sequence colormap.
+  seqs %>%
+    plot_sequence_colormap %>%
+    expect_s3_class("ggplot")
+
+  ## Sequence logo.
+  seqs %>%
+    plot_sequence_logo %>%
+    expect_s3_class("ggplot")
+})
+
+test_that("Dinucleotide frequencies", {
+  ## DataFrame with frequencies.
+  seqs <- tsr_explorer(TSSs["S288C_WT_1"], genome_assembly=assembly) %>%
+    format_counts(data_type="tss") %>%
+    dinucleotide_frequencies
+  seqs %>%
+    expect_s4_class("DataFrame") %>%
+    expect_named(c("sample", "dinucleotide", "count", "freqs"))
+
+  ## Dinucleotide plot.
+  seqs %>%
+    plot_dinucleotide_frequencies %>%
+    expect_s3_class("ggplot")
+})


### PR DESCRIPTION
Wrote basic units tests for:
- ensuring `tss_sequences` returns a proper DataFrame.
- checking that a plot is returned with `plot_sequence_logo` and `plot_sequence_colormap`.
- checking that `dinucleotide_frequencies` returns a proper DataFrame.
- also making sure `plot_dinucleotide_frequencies` returns a plot.

Fixes #82 which was caused by an incorrect variable name for setting factor levels when samples are specified