### PR TITLE
allow specification of IQR upper and lower bounds for tsr_metrics

### DIFF
--- a/man/iq_range-function.Rd
+++ b/man/iq_range-function.Rd
@@ -4,10 +4,14 @@
 \alias{iq_range}
 \title{Interquartile Range}
 \usage{
-iq_range(tss_table)
+iq_range(tss_table, iqr_upper, iqr_lower)
 }
 \arguments{
 \item{tss_table}{data.table of TSSs}
+
+\item{iqr_upper}{Upper IQR cutoff value.}
+
+\item{iqr_lower}{Lower IQR cutoff value.}
 }
 \description{
 Calculate IQR.

--- a/man/tsr_metrics-function.Rd
+++ b/man/tsr_metrics-function.Rd
@@ -4,10 +4,14 @@
 \alias{tsr_metrics}
 \title{TSR Metrics}
 \usage{
-tsr_metrics(experiment)
+tsr_metrics(experiment, iqr_lower = 0.1, iqr_upper = 0.9)
 }
 \arguments{
 \item{experiment}{TSRexploreR object.}
+
+\item{iqr_lower}{Lower IQR cutoff value.}
+
+\item{iqr_upper}{Upper IQR cutoff value.}
 }
 \description{
 Calculate TSR Metrics.


### PR DESCRIPTION
Added arguments `iqr_lower` and `iqr_upper` to `tsr_metrics` that allow specification of the IQR bounds. Addresses #74.