### PR TITLE
Adding annotation category filter to export_for_enrichment

### DIFF
--- a/man/export_for_enrichment-function.Rd
+++ b/man/export_for_enrichment-function.Rd
@@ -10,7 +10,8 @@ export_for_enrichment(
   de_comparisons = "all",
   log2fc_cutoff = 1,
   fdr_cutoff = 0.05,
-  keep_unchanged = FALSE
+  keep_unchanged = FALSE,
+  anno_categories = NULL
 )
 }
 \arguments{
@@ -27,6 +28,9 @@ TSRs.}
 
 \item{keep_unchanged}{Logical for inclusion of genes not significantly changed in
 the exported list.}
+
+\item{Vector}{of annotation categories to keep.
+If NULL no filtering by annotation type occurs.}
 }
 \description{
 Export differential features for use in clusterProfiler term enrichment.


### PR DESCRIPTION
Added argument `anno_categories` to `export_for_enrichment` that can take a vector of annotation categories to retain.

fixes #84 