### PR TITLE
plot_heatmap unit tests; fixing sample order bug in plot_genomic_distribution

### DIFF
--- a/R/genomic_distribution.R
+++ b/R/genomic_distribution.R
@@ -75,7 +75,7 @@ plot_genomic_distribution <- function(
   selected_samples <- condition_data(selected_samples, data_conditions)
 
   ## Calculate distribution.
-  selected_samples <- rbindlist(selected_samples, idcol="samples")
+  selected_samples <- rbindlist(selected_samples, idcol="sample")
 
   grouping_status <- case_when(
     !is.null(data_conditions$quantiling) ~ "row_quantile",
@@ -87,11 +87,11 @@ plot_genomic_distribution <- function(
 
   ## Order samples if required.
   if (!all(samples == "all")) {
-    genomic_dist[, samples := factor(samples, levels=samples)]
+    genomic_dist[, sample := factor(sample, levels=samples)]
   }
 
   ## Plot the genomic distribution.
-  p <- ggplot(genomic_dist, aes(x=.data$samples, y=.data$count, fill=fct_rev(.data$simple_annotations))) +
+  p <- ggplot(genomic_dist, aes(x=.data$sample, y=.data$count, fill=fct_rev(.data$simple_annotations))) +
     geom_col(position="fill", ...) +
     coord_flip() +
     ylab("Fraction") +
@@ -120,18 +120,18 @@ plot_genomic_distribution <- function(
     setnames(selected_samples, old=grouping_status, new="grouping")
     genomic_distribution <- selected_samples[,
       .(count=.N),
-      by=.(samples, simple_annotations, grouping)
+      by=.(sample, simple_annotations, grouping)
     ][,
       .(simple_annotations, count, fraction=count / sum(count)),
-      by=.(samples, grouping)
+      by=.(sample, grouping)
     ]
   } else {
     genomic_distribution <- selected_samples[,
       .(count=.N),
-      by=.(samples, simple_annotations)
+      by=.(sample, simple_annotations)
     ][,
       .(simple_annotations, count, fraction=count / sum(count)),
-      by=samples
+      by=sample
     ]
   }
 

--- a/tests/testthat/test-TSS_processing.R
+++ b/tests/testthat/test-TSS_processing.R
@@ -1,4 +1,3 @@
-context("TSS Processing")
 source("setup.R")
 
 test_that("TSS Normalization", {

--- a/tests/testthat/test-bam_processing.R
+++ b/tests/testthat/test-bam_processing.R
@@ -1,5 +1,3 @@
-context("Bam Importing and Processing")
-
 bam_file <- system.file("extdata", "S288C.bam", package="TSRexploreR")
 samples <- data.frame(sample_name="S288C", file_1=bam_file, file_2=NA)
 

--- a/tests/testthat/test-differential_features.R
+++ b/tests/testthat/test-differential_features.R
@@ -1,5 +1,3 @@
-context("Differential TSSs/TSRs")
-
 source("setup.R")
 
 sample_sheet <- data.frame(

--- a/tests/testthat/test-genome.R
+++ b/tests/testthat/test-genome.R
@@ -1,5 +1,3 @@
-context("Genome Annotation and Assembly")
-
 source("setup.R")
 library("TxDb.Scerevisiae.UCSC.sacCer3.sgdGene")
 library("BSgenome.Scerevisiae.UCSC.sacCer3")

--- a/tests/testthat/test-heatmap.R
+++ b/tests/testthat/test-heatmap.R
@@ -1,0 +1,31 @@
+
+source("setup.R")
+
+test_that("TSS and TSR heatmaps.", {
+
+  ## TSS heatmaps.
+  tsre <- TSSs["S288C_WT_1"] %>%
+    tsr_explorer(genome_annotation=annotation) %>%
+    prepare_counts(data_type="tss") %>%
+    annotate_features(data_type="tss")
+
+  # TSS heatmap.
+  plot_heatmap(tsre, data_type="tss") %>%
+    expect_s3_object("ggplot")
+  # TSS heatmap with rasterization.
+  plot_heatmap(tsre, data_type="tss", rasterization=TRUE) %>%
+    expect_s3_object("ggplot")
+
+  ## TSR heatmaps.
+  tsre <- tsre %>%
+    tss_clustering(threshold=3) %>%
+    annotate_features(data_type="tsr")
+
+  # TSR heatmap.
+  plot_heatmap(tsre, data_type="tsr") %>%
+    expect_s3_object("ggplot")
+  # TSR heatmap with rasterization.
+  plot_heatmap(tsre, data-type="tsr", rasterization=TRUE) %>%
+    expect_s3_object("ggplot")
+
+})

--- a/tests/testthat/test-ranges.R
+++ b/tests/testthat/test-ranges.R
@@ -1,4 +1,3 @@
-context("Handling of Ranges")
 source("setup.R")
 
 test_that("Proper handling of TSS ranges.", {

--- a/tests/testthat/test-sequence_related.R
+++ b/tests/testthat/test-sequence_related.R
@@ -1,4 +1,3 @@
-context("Sequence Retrieval Functions")
 source("setup.R")
 
 test_that("TSS sequence colormap and sequence logo", {


### PR DESCRIPTION
Added unit tests for TSS and TSR heatmaps generated from `plot_heatmaps`.

Fixed a bug in `plot_genomic_distribution` that caused an error when sample names were specified.