### PR TITLE
Option to return a table for many plotting functions.

### DIFF
--- a/R/correlation.R
+++ b/R/correlation.R
@@ -130,6 +130,7 @@ plot_correlation <- function(
     is.null(threshold) ||
     (is.numeric(threshold) && threshold > 0)
   )
+  assert_that(is.flag(return_matrix))
 
   ## Get data from proper slot.
   normalized_counts <- experiment %>%

--- a/R/correlation.R
+++ b/R/correlation.R
@@ -70,6 +70,7 @@ find_correlation <- function(
 #'   on rows and columns.
 #' @param heatmap_colors Vector of colors for heatmap.
 #' @param show_values Logical for whether to show correlation values on the heatmap.
+#' @param return_matrix Return the correlation matrix without plotting correlation heatmap.
 #' @param ... Additional arguments passed to ComplexHeatmap::Heatmap.
 #'
 #' @details
@@ -111,6 +112,7 @@ plot_correlation <- function(
   cluster_samples=FALSE,
   heatmap_colors=NULL,
   show_values=TRUE,
+  return_matrix=FALSE,
   ...
 ) {
 
@@ -153,6 +155,9 @@ plot_correlation <- function(
 
   ## Correlation Matrix.
   cor_mat <- cor(normalized_counts, method=correlation_metric)
+
+  ## Return correlation matrix if requested.
+  if (return_matrix) return(cor_mat)
 
   ## ComplexHeatmap Correlation Plot.
   heatmap_args <- list(

--- a/R/diff_exp_plots.R
+++ b/R/diff_exp_plots.R
@@ -205,6 +205,7 @@ plot_num_de <- function(
   log2fc_cutoff=1,
   fdr_cutoff=0.05,
   keep_unchanged=FALSE,
+  return_table=FALSE,
   ...
 ) {
 
@@ -217,6 +218,8 @@ plot_num_de <- function(
   assert_that(is.character(de_comparisons))
   assert_that(is.numeric(log2fc_cutoff) && log2fc_cutoff >= 0)
   assert_that(is.numeric(fdr_cutoff) && (fdr_cutoff > 0 & fdr_cutoff <= 1))
+  assert_that(is.flag(keep_unchanged))
+  assert_that(is.flag(return_table))
 
   ## Get appropriate samples.
   de_samples <- extract_de(experiment, data_type, de_comparisons)
@@ -240,6 +243,9 @@ plot_num_de <- function(
   if (!all(de_comparisons == "all")) {
     de_samples[, samples := factor(samples, levels=de_comparisons)]
   }
+
+  ## Return table if requested.
+  if (return_table) return(as.data.frame(de_samples))
 
   ## Plot data.
   p <- ggplot(de_samples, aes(x=.data$samples, y=.data$count, fill=.data$de_status)) +

--- a/R/dinucleotide.R
+++ b/R/dinucleotide.R
@@ -51,6 +51,7 @@ plot_dinucleotide_frequencies <- function(
   dominant=FALSE,
   data_conditions=NULL,
   ncol=3,
+  return_table=FALSE,
   ...
 ) {
 
@@ -65,6 +66,7 @@ plot_dinucleotide_frequencies <- function(
   assert_that(is.flag(use_normalized))
   assert_that(is.flag(dominant))
   assert_that(is.null(data_conditions) || is.list(data_conditions))
+  assert_that(is.flag(return_table))
 
   ## Load genome assembly.
   fasta_assembly <- .prepare_assembly(genome_assembly, experiment)
@@ -125,6 +127,9 @@ plot_dinucleotide_frequencies <- function(
   if (!all(samples == "all")) {
     freqs[, sample := factor(sample, levels=samples)]
   }
+
+  ## Return table if requested.
+  if (return_table) return(as.data.frame(freqs))
 
   ## PLot dinucleotide frequencies.
   p <- ggplot(freqs, aes(x=.data$dinucleotide, y=.data$freqs)) +

--- a/R/gene_plots.R
+++ b/R/gene_plots.R
@@ -49,6 +49,7 @@ plot_detected_features <- function(
   dominant=FALSE,
   use_normalized=FALSE,
   data_conditions=NULL,
+  return_table=FALSE,
   ...
 ) {
 
@@ -60,6 +61,7 @@ plot_detected_features <- function(
   assert_that(is.flag(dominant))
   assert_that(is.flag(use_normalized))
   assert_that(is.null(data_conditions) || is.list(data_conditions))
+  assert_that(is.flag(return_table))
 
   ## Get sample data.
   sample_data <- experiment %>%
@@ -106,6 +108,9 @@ plot_detected_features <- function(
   if (!all(samples == "all")) {
     sample_data[, sample := factor(sample, levels=samples)]
   }
+
+  ## Return a table if required.
+  if (return_table) return(as.data.frame(sample_data))
 
   ## Plot data.
   p <- ggplot(plot_data, aes(x=.data$sample, y=.data$feature_count, fill=.data$count_type)) +

--- a/R/genomic_distribution.R
+++ b/R/genomic_distribution.R
@@ -48,6 +48,7 @@ plot_genomic_distribution <- function(
   use_normalized=FALSE,
   dominant=FALSE,
   data_conditions=NULL,
+  return_table=FALSE,
   ...
 ) {
 
@@ -58,6 +59,7 @@ plot_genomic_distribution <- function(
   assert_that(is.null(threshold) || (is.numeric(threshold) && threshold >= 0))
   assert_that(is.flag(dominant))
   assert_that(is.null(data_conditions) || is.list(data_conditions))
+  assert_that(is.flag(return_table))
 
   ## Get samples.
   selected_samples <- experiment %>%
@@ -89,6 +91,9 @@ plot_genomic_distribution <- function(
   if (!all(samples == "all")) {
     genomic_dist[, sample := factor(sample, levels=samples)]
   }
+
+  ## Return table is requested.
+  if (return_table) return(as.data.frame(genomic_dist))
 
   ## Plot the genomic distribution.
   p <- ggplot(genomic_dist, aes(x=.data$sample, y=.data$count, fill=fct_rev(.data$simple_annotations))) +

--- a/R/merge.R
+++ b/R/merge.R
@@ -22,7 +22,7 @@ merge_samples <- function(
   merge_group=NULL,
   merge_list=NULL,
   max_distance=NULL,
-  genome_annotation=NULL
+  genome_assembly=NULL
 ) {
 
   ## Check inputs.

--- a/R/motif.R
+++ b/R/motif.R
@@ -408,7 +408,7 @@ plot_sequence_colormap <- function(
   if (!all(samples == "all")) {
     long_data[, sample := factor(sample, levels=samples)]
   }
-    
+
   ## Plot sequence colormap
   p <- ggplot(long_data, aes(x=.data$position, y=.data$FHASH))
 

--- a/R/params.R
+++ b/R/params.R
@@ -19,5 +19,6 @@
 #' @param data_conditions Apply advanced conditions to the data.
 #' @param rasterize Rasterize a ggplot.
 #' @param raster_dpi If rasterization is set, this controls the rasterization DPI.
+#' @param return_table Return a table of results instead of a plot.
 
 common_params <- function(x) NULL

--- a/R/shifting_plots.R
+++ b/R/shifting_plots.R
@@ -60,19 +60,23 @@ plot_shift_rank <- function(
 #' Shift Count Plot
 #'
 #' @inheritParams common_params
+#' @param ... Arguments passed to geom_col
 #'
 #' @export
 
 plot_shift_count <- function(
   experiment,
   samples="all",
-  ncol=3
+  ncol=3,
+  return_table=FALSE,
+  ...
 ) {
 
   ## Check inputs.
   assert_that(is(experiment, "tsr_explorer"))
   assert_that(is.character(samples))
   assert_that(is.count(ncol))
+  assert_that(is.flag(return_table))
 
   ## Get samples.
   if (all(samples == "all")) {
@@ -98,9 +102,12 @@ plot_shift_count <- function(
     shift_count[, comparison := factor(comparison, levels=samples)]
   }
 
+  ## Return a table if requested.
+  if (return_table) return(as.data.frame(shift_count))
+
   ## bar plot of shifting status.
   p <- ggplot(shift_count, aes(x=.data$comparison, y=.data$count, fill=.data$shift_status)) +
-    geom_col(position="stack")
+    geom_col(position="stack", ...)
 
   return(p)
 }

--- a/R/softclip_analysis.R
+++ b/R/softclip_analysis.R
@@ -20,6 +20,7 @@ softclip_composition <- function(
   assert_that(is.character(samples))
   assert_that(is.null(n_bases) || is.count(n_bases))
   assert_that(is.count(ncol))
+  assert_that(is.flag(return_table))
 
   ## Retrieve selected samples.
   if (all(samples == "all")) {

--- a/R/softclip_analysis.R
+++ b/R/softclip_analysis.R
@@ -2,6 +2,7 @@
 #'
 #' @inheritParams common_params
 #' @param n_bases Number of bases from -1 position to keep
+#' @param ... Arguments passed to geom_col
 #'
 #' @export
 
@@ -9,7 +10,9 @@ softclip_composition <- function(
   experiment,
   samples="all",
   n_bases=NULL,
-  ncol=3
+  ncol=3,
+  return_table=FALSE,
+  ...
 ) {
 
   ## Input checks.
@@ -75,6 +78,9 @@ softclip_composition <- function(
   if (!all(samples == "all")) {
     select_samples[, sample := factor(sample, levels=samples)]
   }
+
+  ## Return table if requested.
+  if (return_table) return(as.data.frame(select_samples))
 
   ## Plot frequencies.
   p <- ggplot(select_samples, aes(x=.data$sample, y=.data$count)) +

--- a/R/thresholding.R
+++ b/R/thresholding.R
@@ -145,6 +145,7 @@ plot_threshold_exploration <- function(
   use_normalized=FALSE,
   ncol=1,
   point_size=1,
+  return_table=FALSE,
   ...
 ) {
 
@@ -165,6 +166,9 @@ plot_threshold_exploration <- function(
     samples,
     use_normalized
   ) 
+
+  ## Return table if requested.
+  if (return_table) return(as.data.frame(threshold_data))
 
   ## Plot data.
   p <- ggplot(threshold_data, aes(x=.data$threshold, y=.data$frac_promoter_proximal)) +

--- a/R/thresholding.R
+++ b/R/thresholding.R
@@ -157,6 +157,7 @@ plot_threshold_exploration <- function(
   assert_that(is.character(samples))
   assert_that(is.numeric(steps) && steps >= 0.1)
   assert_that(is.flag(use_normalized))
+  assert_that(is.flag(return_table))
 
   ## Threshold exploration.
   threshold_data <- .explore_thresholds(

--- a/man/common_params.Rd
+++ b/man/common_params.Rd
@@ -39,6 +39,8 @@ highest-scoring TSR per gene or transcript.}
 \item{rasterize}{Rasterize a ggplot.}
 
 \item{raster_dpi}{If rasterization is set, this controls the rasterization DPI.}
+
+\item{return_table}{Return a table of results instead of a plot.}
 }
 \description{
 Function to hold common parameters.

--- a/man/merge_samples-function.Rd
+++ b/man/merge_samples-function.Rd
@@ -12,7 +12,7 @@ merge_samples(
   merge_group = NULL,
   merge_list = NULL,
   max_distance = NULL,
-  genome_annotation = NULL
+  genome_assembly = NULL
 )
 }
 \arguments{
@@ -32,7 +32,7 @@ Additional meta-data columns can be added with sample information such as condit
 
 \item{max_distance}{Merge TSRs within this distance.}
 
-\item{genome_annotation}{Genome annotation in GTF, GFF3, or TxDb format.}
+\item{genome_assembly}{Genome assembly in FASTA or BSgenome format.}
 
 \item{merge_replicates}{If 'TRUE', replicate groups will be merged.}
 

--- a/man/plot_correlation-function.Rd
+++ b/man/plot_correlation-function.Rd
@@ -15,6 +15,7 @@ plot_correlation(
   cluster_samples = FALSE,
   heatmap_colors = NULL,
   show_values = TRUE,
+  return_matrix = FALSE,
   ...
 )
 }
@@ -39,6 +40,8 @@ on rows and columns.}
 \item{heatmap_colors}{Vector of colors for heatmap.}
 
 \item{show_values}{Logical for whether to show correlation values on the heatmap.}
+
+\item{return_matrix}{Return the correlation matrix without plotting correlation heatmap.}
 
 \item{...}{Additional arguments passed to ComplexHeatmap::Heatmap.}
 }

--- a/man/plot_detected_features.Rd
+++ b/man/plot_detected_features.Rd
@@ -12,6 +12,7 @@ plot_detected_features(
   dominant = FALSE,
   use_normalized = FALSE,
   data_conditions = NULL,
+  return_table = FALSE,
   ...
 )
 }
@@ -30,6 +31,8 @@ highest-scoring TSR per gene or transcript.}
 \item{use_normalized}{Whether to use the normalized (TRUE) or raw (FALSE) counts.}
 
 \item{data_conditions}{Apply advanced conditions to the data.}
+
+\item{return_table}{Return a table of results instead of a plot.}
 
 \item{...}{Arguments passed to geom_col.}
 }

--- a/man/plot_dinucleotide_frequencies.Rd
+++ b/man/plot_dinucleotide_frequencies.Rd
@@ -13,6 +13,7 @@ plot_dinucleotide_frequencies(
   dominant = FALSE,
   data_conditions = NULL,
   ncol = 3,
+  return_table = FALSE,
   ...
 )
 }
@@ -33,6 +34,8 @@ highest-scoring TSR per gene or transcript.}
 \item{data_conditions}{Apply advanced conditions to the data.}
 
 \item{ncol}{Integer specifying the number of columns to arrange multiple plots.}
+
+\item{return_table}{Return a table of results instead of a plot.}
 
 \item{...}{Arguments passed to geom_col}
 }

--- a/man/plot_genomic_distribution.Rd
+++ b/man/plot_genomic_distribution.Rd
@@ -12,6 +12,7 @@ plot_genomic_distribution(
   use_normalized = FALSE,
   dominant = FALSE,
   data_conditions = NULL,
+  return_table = FALSE,
   ...
 )
 }
@@ -30,6 +31,8 @@ plot_genomic_distribution(
 highest-scoring TSR per gene or transcript.}
 
 \item{data_conditions}{Apply advanced conditions to the data.}
+
+\item{return_table}{Return a table of results instead of a plot.}
 
 \item{...}{Arguments passed to geom_col.}
 }

--- a/man/plot_num_de-function.Rd
+++ b/man/plot_num_de-function.Rd
@@ -11,6 +11,7 @@ plot_num_de(
   log2fc_cutoff = 1,
   fdr_cutoff = 0.05,
   keep_unchanged = FALSE,
+  return_table = FALSE,
   ...
 )
 }
@@ -26,6 +27,8 @@ plot_num_de(
 \item{fdr_cutoff}{Differential features not meeting this significance threshold will not be considered.}
 
 \item{keep_unchanged}{Whether to include unchanged features in the plot.}
+
+\item{return_table}{Return a table of results instead of a plot.}
 
 \item{...}{Additional arguments passed to geom_col.}
 }

--- a/man/plot_shift_count.Rd
+++ b/man/plot_shift_count.Rd
@@ -4,7 +4,13 @@
 \alias{plot_shift_count}
 \title{Shift Count Plot}
 \usage{
-plot_shift_count(experiment, samples = "all", ncol = 3)
+plot_shift_count(
+  experiment,
+  samples = "all",
+  ncol = 3,
+  return_table = FALSE,
+  ...
+)
 }
 \arguments{
 \item{experiment}{TSRexploreR object.}
@@ -12,6 +18,10 @@ plot_shift_count(experiment, samples = "all", ncol = 3)
 \item{samples}{A vector of sample names to analyze.}
 
 \item{ncol}{Integer specifying the number of columns to arrange multiple plots.}
+
+\item{return_table}{Return a table of results instead of a plot.}
+
+\item{...}{Arguments passed to geom_col}
 }
 \description{
 Shift Count Plot

--- a/man/plot_threshold_exploration-function.Rd
+++ b/man/plot_threshold_exploration-function.Rd
@@ -12,6 +12,7 @@ plot_threshold_exploration(
   use_normalized = FALSE,
   ncol = 1,
   point_size = 1,
+  return_table = FALSE,
   ...
 )
 }
@@ -29,6 +30,8 @@ plot_threshold_exploration(
 \item{ncol}{Integer specifying the number of columns to arrange multiple plots.}
 
 \item{point_size}{The size of the points on the plot}
+
+\item{return_table}{Return a table of results instead of a plot.}
 
 \item{...}{Arguments passed to geom_point}
 }

--- a/man/softclip_composition.Rd
+++ b/man/softclip_composition.Rd
@@ -4,7 +4,14 @@
 \alias{softclip_composition}
 \title{Composition of Softclipped Bases}
 \usage{
-softclip_composition(experiment, samples = "all", n_bases = NULL, ncol = 3)
+softclip_composition(
+  experiment,
+  samples = "all",
+  n_bases = NULL,
+  ncol = 3,
+  return_table = FALSE,
+  ...
+)
 }
 \arguments{
 \item{experiment}{TSRexploreR object.}
@@ -14,6 +21,10 @@ softclip_composition(experiment, samples = "all", n_bases = NULL, ncol = 3)
 \item{n_bases}{Number of bases from -1 position to keep}
 
 \item{ncol}{Integer specifying the number of columns to arrange multiple plots.}
+
+\item{return_table}{Return a table of results instead of a plot.}
+
+\item{...}{Arguments passed to geom_col}
 }
 \description{
 Composition of Softclipped Bases

--- a/tests/testthat/test-heatmap.R
+++ b/tests/testthat/test-heatmap.R
@@ -6,15 +6,15 @@ test_that("TSS and TSR heatmaps.", {
   ## TSS heatmaps.
   tsre <- TSSs["S288C_WT_1"] %>%
     tsr_explorer(genome_annotation=annotation) %>%
-    prepare_counts(data_type="tss") %>%
+    format_counts(data_type="tss") %>%
     annotate_features(data_type="tss")
 
   # TSS heatmap.
   plot_heatmap(tsre, data_type="tss") %>%
-    expect_s3_object("ggplot")
+    expect_s3_class("ggplot")
   # TSS heatmap with rasterization.
   plot_heatmap(tsre, data_type="tss", rasterization=TRUE) %>%
-    expect_s3_object("ggplot")
+    expect_s3_class("ggplot")
 
   ## TSR heatmaps.
   tsre <- tsre %>%
@@ -23,9 +23,9 @@ test_that("TSS and TSR heatmaps.", {
 
   # TSR heatmap.
   plot_heatmap(tsre, data_type="tsr") %>%
-    expect_s3_object("ggplot")
+    expect_s3_class("ggplot")
   # TSR heatmap with rasterization.
-  plot_heatmap(tsre, data-type="tsr", rasterization=TRUE) %>%
-    expect_s3_object("ggplot")
+  plot_heatmap(tsre, data_type="tsr", rasterization=TRUE) %>%
+    expect_s3_class("ggplot")
 
 })


### PR DESCRIPTION
Added the ability to return a table instead of a plot for many plotting functions by setting `return_table=TRUE`.

Functions changed:
- `plot_threshold_exploration`
- `plot_correlation`
- `plot_dinucleotide_frequencies`
- `plot_detected_features`
- `plot_genomic_distribution`
- `plot_shift_count`
- `softclip_composition`
- `plot_num_de`