### PR TITLE
Fixed sample ordering in a few plots

### DIFF
--- a/R/gene_plots.R
+++ b/R/gene_plots.R
@@ -106,11 +106,11 @@ plot_detected_features <- function(
 
   ## Order samples if required.
   if (!all(samples == "all")) {
-    sample_data[, sample := factor(sample, levels=samples)]
+    plot_data[, sample := factor(sample, levels=samples)]
   }
 
   ## Return a table if required.
-  if (return_table) return(as.data.frame(sample_data))
+  if (return_table) return(as.data.frame(plot_data))
 
   ## Plot data.
   p <- ggplot(plot_data, aes(x=.data$sample, y=.data$feature_count, fill=.data$count_type)) +

--- a/R/genomic_distribution.R
+++ b/R/genomic_distribution.R
@@ -89,7 +89,7 @@ plot_genomic_distribution <- function(
 
   ## Order samples if required.
   if (!all(samples == "all")) {
-    genomic_dist[, sample := factor(sample, levels=samples)]
+    genomic_dist[, sample := factor(sample, levels=rev(samples))]
   }
 
   ## Return table is requested.

--- a/R/motif.R
+++ b/R/motif.R
@@ -259,7 +259,7 @@ plot_sequence_logo <- function(
       # labels=c(-distance, -1, +1, distance + 1)
       #)
   } else {
-    p <- rev(sequences) %>%
+    p <- sequences %>%
       map(function(x) {
         ggseqlogo(x, ncol=ncol, ...) +
           theme(text=element_text(size=font_size)) #+


### PR DESCRIPTION
Sample orders should now not be reversed for `plot_genomic_distribution` and `plot_sequence_logo`. I also fixed a typo that resulted in sample ordering not working with `plot_detected_features`.

fixes #115 