### PR TITLE
added threshold for singlets in tss_clustering

### DIFF
--- a/man/dot-aggr_scores.Rd
+++ b/man/dot-aggr_scores.Rd
@@ -4,12 +4,14 @@
 \alias{.aggr_scores}
 \title{Aggregate Scores}
 \usage{
-.aggr_scores(granges, maxdist, maxwidth)
+.aggr_scores(granges, maxdist, maxwidth, sthresh)
 }
 \arguments{
 \item{granges}{GRanges.}
 
 \item{maxdist}{Maximum distance to cluster.}
+
+\item{sthresh}{Singlet threshold.}
 }
 \description{
 Aggregate Scores

--- a/man/tss_clustering-function.Rd
+++ b/man/tss_clustering-function.Rd
@@ -10,7 +10,8 @@ tss_clustering(
   threshold = NULL,
   n_samples = NULL,
   max_distance = 25,
-  max_width = NULL
+  max_width = NULL,
+  singlet_threshold = NULL
 )
 }
 \arguments{
@@ -26,6 +27,9 @@ number of samples.}
 \item{max_distance}{Maximum allowable distance between TSSs for clustering.}
 
 \item{max_width}{Maximum allowable TSR width.}
+
+\item{singlet_threshold}{TSRs of width 1 must have a score greater than
+or equal to this threshold to be kept.}
 }
 \value{
 TSRexploreR object with TSRs.


### PR DESCRIPTION
Added argument `singlet_threshold` to `tss_clustering` that allows the specification of a score threshold for singlets.