### PR TITLE
further reducing runtime of examples

### DIFF
--- a/R/annotate.R
+++ b/R/annotate.R
@@ -24,10 +24,10 @@
 #' @return TSRexploreR object with annotation data added to TSS or TSR tables.
 #'
 #' @examples
-#' data(TSSs)
+#' data(TSSs_reduced)
 #' annotation <- system.file("extdata", "S288C_Annotation.gtf", package="TSRexploreR")
 #'
-#' tsre <- TSSs[1] %>%
+#' tsre <- TSSs %>%
 #'   tsr_explorer(genome_annotation=annotation) %>%
 #'   format_counts(data_type="tss")
 #'

--- a/R/association.R
+++ b/R/association.R
@@ -23,9 +23,9 @@
 #'   TSSs with the TSRs from the sample of the same name.
 #'   
 #' @examples
-#' data(TSSs)
+#' data(TSSs_reduced)
 #'
-#' tsre <- TSSs[1] %>%
+#' tsre <- TSSs %>%
 #'   tsr_explorer %>%
 #'   format_counts(data_type="tss") %>%
 #'   tss_clustering(threshold=3) %>%

--- a/R/correlation.R
+++ b/R/correlation.R
@@ -33,7 +33,7 @@
 #'   or correlation matrix if 'return_matrix' is TRUE.
 #'
 #' @examples
-#' data(TSSs)
+#' data(TSSs_reduced)
 #'
 #' tsre <- TSSs[1] %>%
 #'   tsr_explorer %>%

--- a/R/data.R
+++ b/R/data.R
@@ -6,3 +6,11 @@
 #' @format A list of GRanges:
 #' @source \href{https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE142524}{GSE14254}
 "TSSs"
+
+#' STRIPE-seq TSSs YDR077W (Diamide)
+#'
+#' STRIPE-seq TSSs after diamide treatment for gene YDR077W
+#'
+#' @format A named list of one GRange.
+#' @source \href{https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE142524}{GSE14254}
+"TSSs_reduced"

--- a/R/data_export.R
+++ b/R/data_export.R
@@ -32,7 +32,7 @@
 #' \code{\link{tsr_import}} to import TSRs.
 #'
 #' @examples
-#' data(TSSs)
+#' data(TSSs_reduced)
 #'
 #' \dontrun{
 #' tsre <- TSSs[1] %>%
@@ -179,9 +179,9 @@ tss_export <- function(
 #'
 #' @examples
 #' \dontrun{
-#' data(TSSs)
+#' data(TSSs_reduced)
 #'
-#' tsre <- TSSs[1] %>%
+#' tsre <- TSSs %>%
 #'   tsr_explorer %>%
 #'   format_counts(data_type="tss") %>%
 #'   tss_clustering(threshold=3)

--- a/R/data_import.R
+++ b/R/data_import.R
@@ -31,10 +31,10 @@
 #'
 #' @examples
 #' \dontrun{
-#' data(TSSs)
+#' data(TSSs_reduced)
 #'
 #' # Export bedgraphs as example data.
-#' tsre <- TSSs[1] %>%
+#' tsre <- TSSs %>%
 #'   tsr_explorer %>%
 #'   format_counts(data_type="tss")
 #' tss_export(tsre)
@@ -270,10 +270,10 @@ tss_import <- function(
 #'
 #' @examples
 #' \dontrun{
-#' data(TSSs)
+#' data(TSSs_reduced)
 #'
 #' # Export bed as example data.
-#' tsre <- TSSs[1] %>%
+#' tsre <- TSSs %>%
 #'   tsr_explorer %>%
 #'   format_counts(data_type="tss") %>%
 #'   tss_clustering(threshold=3)

--- a/R/density_plots.R
+++ b/R/density_plots.R
@@ -37,10 +37,10 @@
 #' @return ggplot2 object of density plot.
 #'
 #' @examples
-#' data(TSSs)
+#' data(TSSs_reduced)
 #' annotation <- system.file("extdata", "S288C_Annotation.gtf", package="TSRexploreR")
 #'
-#' tsre <- TSSs[1] %>%
+#' tsre <- TSSs %>%
 #'   tsr_explorer(genome_annotation=annotation) %>%
 #'   format_counts(data_type="tss") %>%
 #'   annotate_features(data_type="tss")

--- a/R/dinucleotide.R
+++ b/R/dinucleotide.R
@@ -30,10 +30,10 @@
 #'   If 'return_table' is TRUE, a data.frame of underlying data is returned.
 #'
 #' @examples
-#' data(TSSs)
+#' data(TSSs_reduced)
 #' assembly <- system.file("extdata", "S288C_Assembly.fasta", package="TSRexploreR")
 #'
-#' tsre <- TSSs[1] %>%
+#' tsre <- TSSs %>%
 #'   tsr_explorer(genome_assembly=assembly) %>%
 #'   format_counts(data_type="tss")
 #'

--- a/R/gene_plots.R
+++ b/R/gene_plots.R
@@ -28,10 +28,10 @@
 #' \code{\link{annotate_features}} to annotate the TSSs or TSRs.
 #'
 #' @examples
-#' data(TSSs)
+#' data(TSSs_reduced)
 #' annotation <- system.file("extdata", "S288C_Annotation.gtf", package="TSRexploreR")
 #'
-#' tsre <- TSSs[1] %>%
+#' tsre <- TSSs %>%
 #'   tsr_explorer(genome_annotation=annotation) %>%
 #'   format_counts(data_type="tss") %>%
 #'   annotate_features(data_type="tss")

--- a/R/gene_tracks.R
+++ b/R/gene_tracks.R
@@ -33,10 +33,10 @@
 #' @return GViz gene track plot.
 #'
 #' @examples
-#' data(TSSs)
+#' data(TSSs_reduced)
 #' annotation <- system.file("extdata", "S288C_Annotation.gtf", package="TSRexploreR")
 #'
-#' tsre <- TSSs[1] %>%
+#' tsre <- TSSs %>%
 #'   tsr_explorer(genome_annotation=annotation) %>%
 #'   format_counts(data_type="tss") %>%
 #'   tss_clustering(threshold=3)

--- a/R/genomic_distribution.R
+++ b/R/genomic_distribution.R
@@ -30,10 +30,10 @@
 #' @seealso \code{\link{annotate_features}} to annotate TSSs or TSRs.
 #'
 #' @examples
-#' data(TSSs)
+#' data(TSSs_reduced)
 #' annotation <- system.file("extdata", "S288C_Annotation.gtf", package="TSRexploreR")
 #'
-#' tsre <- TSSs[1] %>%
+#' tsre <- TSSs %>%
 #'   tsr_explorer(genome_annotation=annotation) %>%
 #'   format_counts(data_type="tss") %>%
 #'   annotate_features(data_type="tss")

--- a/R/heatmaps.R
+++ b/R/heatmaps.R
@@ -137,10 +137,10 @@
 #' \code{\link{annotate_features}} to annotate the TSSs or TSRs.
 #'
 #' @examples
-#' data(TSSs)
+#' data(TSSs_reduced)
 #' annotation <- system.file("extdata", "S288C_Annotation.gtf", package="TSRexploreR")
 #'
-#' tsre <- TSSs[1] %>%
+#' tsre <- TSSs %>%
 #'   tsr_explorer(genome_annotation=annotation) %>%
 #'   format_counts(data_type="tss") %>%
 #'   annotate_features(data_type="tss")

--- a/R/motif.R
+++ b/R/motif.R
@@ -141,10 +141,10 @@
 #' \code{\link{plot_sequence_colormap}} for a sequence color map plot.
 #'
 #' @examples
-#' data(TSSs)
+#' data(TSSs_reduced)
 #' assembly <- system.file("extdata", "S288C_Assembly.fasta", package="TSRexploreR")
 #'
-#' tsre <- TSSs[1] %>%
+#' tsre <- TSSs %>%
 #'   tsr_explorer(genome_assembly=assembly) %>%
 #'   format_counts(data_type="tss")
 #' p <- plot_sequence_logo(tsre, distance=5)
@@ -308,10 +308,10 @@ plot_sequence_logo <- function(
 #' \code{\link{plot_sequence_logo}} to plot a sequence logo.
 #'
 #' @examples
-#' data(TSSs)
+#' data(TSSs_reduced)
 #' assembly <- system.file("extdata", "S288C_Assembly.fasta", package="TSRexploreR")
 #'
-#' tsre <- TSSs[1] %>%
+#' tsre <- TSSs %>%
 #'   tsr_explorer(genome_assembly=assembly) %>%
 #'   format_counts(data_type="tss")
 #' p <- plot_sequence_colormap(tsre, distance=5)

--- a/R/prepare_counts.R
+++ b/R/prepare_counts.R
@@ -16,9 +16,9 @@
 #'    in data.table format.
 #'
 #' @examples
-#' data(TSSs)
+#' data(TSSs_reduced)
 #'
-#' TSSs[1] %>%
+#' TSSs %>%
 #'   tsr_explorer %>%
 #'   format_counts(data_type="tss")
 #'

--- a/R/thresholding.R
+++ b/R/thresholding.R
@@ -129,10 +129,10 @@
 #' \code{\link{apply_threshold}} to permantly filter TSSs below threshold value.
 #'
 #' @examples
-#' data(TSSs)
+#' data(TSSs_reduced)
 #' annotation <- system.file("extdata", "S288C_Annotation.gtf", package="TSRexploreR")
 #'
-#' tsre <- TSSs[1] %>%
+#' tsre <- TSSs %>%
 #'   tsr_explorer(genome_annotation=annotation) %>%
 #'   format_counts(data_type="tss") %>%
 #'   annotate_features(data_type="tss")
@@ -244,9 +244,9 @@ apply_threshold <- function(
 
   ## Filter TSSs below threshold.
   if (!is.null(n_samples)) {
-    count_mat <- count_mat[rowSums(count_mat >= threshold) >= n_samples, ]
+    count_mat <- count_mat[rowSums(count_mat >= threshold) >= n_samples, , drop=FALSE]
   } else {
-    count_mat <- count_mat[rowSums(count_mat >= threshold) == ncol(count_mat), ]
+    count_mat <- count_mat[rowSums(count_mat >= threshold) == ncol(count_mat), , drop=FALSE]
   }
 
   ## Keep only surviving TSSs in each sample.

--- a/R/tsr_metrics.R
+++ b/R/tsr_metrics.R
@@ -19,9 +19,9 @@
 #'   TSSs and TSRs.
 #'
 #' @examples
-#' data(TSSs)
+#' data(TSSs_reduced)
 #'
-#' tsre <- TSSs[1] %>%
+#' tsre <- TSSs %>%
 #'   tsr_explorer %>%
 #'   format_counts(data_type="tss") %>%
 #'   tss_clustering(threshold=3) %>%

--- a/R/tsr_plots.R
+++ b/R/tsr_plots.R
@@ -31,9 +31,9 @@
 #' \code{\link{tsr_metrics}} to calculate additional TSR metrics.
 #'
 #' @examples
-#' data(TSSs)
+#' data(TSSs_reduced)
 #'
-#' tsre <- TSSs[1] %>%
+#' tsre <- TSSs %>%
 #'   tsr_explorer %>%
 #'   format_counts(data_type="tss") %>%
 #'   tss_clustering(threshold=3)

--- a/R/tss_metrics.R
+++ b/R/tss_metrics.R
@@ -28,10 +28,10 @@
 #'   dominant TSS per TSR.
 #'
 #' @examples
-#' data(TSSs)
+#' data(TSSs_reduced)
 #' annotation <- system.file("extdata", "S288C_Annotation.gtf", package="TSRexploreR")
 #'
-#' tsre <- TSSs[1] %>%
+#' tsre <- TSSs %>%
 #'   tsr_explorer(genome_annotation=annotation) %>%
 #'   format_counts(data_type="tss") %>%
 #'   tss_clustering(threshold=3) %>%

--- a/man/annotate_features.Rd
+++ b/man/annotate_features.Rd
@@ -45,10 +45,10 @@ TSSs or TSRs overlapping a gene on the opposite strand
   will be marked as 'Antisense'.
 }
 \examples{
-data(TSSs)
+data(TSSs_reduced)
 annotation <- system.file("extdata", "S288C_Annotation.gtf", package="TSRexploreR")
 
-tsre <- TSSs[1] \%>\%
+tsre <- TSSs \%>\%
   tsr_explorer(genome_annotation=annotation) \%>\%
   format_counts(data_type="tss")
 

--- a/man/associate_with_tsr.Rd
+++ b/man/associate_with_tsr.Rd
@@ -31,9 +31,9 @@ TSS samples can be associated with TSR samples using a list or sample sheet.
   TSSs with the TSRs from the sample of the same name.
 }
 \examples{
-data(TSSs)
+data(TSSs_reduced)
 
-tsre <- TSSs[1] \%>\%
+tsre <- TSSs \%>\%
   tsr_explorer \%>\%
   format_counts(data_type="tss") \%>\%
   tss_clustering(threshold=3) \%>\%

--- a/man/format_counts.Rd
+++ b/man/format_counts.Rd
@@ -27,9 +27,9 @@ This function converts these into data.table format,
   and adds a few important columns for downstream analysis.
 }
 \examples{
-data(TSSs)
+data(TSSs_reduced)
 
-TSSs[1] \%>\%
+TSSs \%>\%
   tsr_explorer \%>\%
   format_counts(data_type="tss")
 

--- a/man/gene_tracks.Rd
+++ b/man/gene_tracks.Rd
@@ -71,10 +71,10 @@ The gene or transcript name should be supplied to 'feature_name'.
   or the feature boundaries (if gene/transcript).
 }
 \examples{
-data(TSSs)
+data(TSSs_reduced)
 annotation <- system.file("extdata", "S288C_Annotation.gtf", package="TSRexploreR")
 
-tsre <- TSSs[1] \%>\%
+tsre <- TSSs \%>\%
   tsr_explorer(genome_annotation=annotation) \%>\%
   format_counts(data_type="tss") \%>\%
   tss_clustering(threshold=3)

--- a/man/mark_dominant.Rd
+++ b/man/mark_dominant.Rd
@@ -47,10 +47,10 @@ dominant TSS per TSR, and for TSRs the dominant TSR per gene is marked. For TSSs
 'gene' can also be specified, which will mark the dominant TSS per gene.
 }
 \examples{
-data(TSSs)
+data(TSSs_reduced)
 annotation <- system.file("extdata", "S288C_Annotation.gtf", package="TSRexploreR")
 
-tsre <- TSSs[1] \%>\%
+tsre <- TSSs \%>\%
   tsr_explorer(genome_annotation=annotation) \%>\%
   format_counts(data_type="tss") \%>\%
   tss_clustering(threshold=3) \%>\%

--- a/man/plot_correlation.Rd
+++ b/man/plot_correlation.Rd
@@ -64,7 +64,7 @@ such as STRIPE-seq vs. CAGE, due to the expectation of a roughly linear relation
 between the ranks, rather than the specific values, of each feature.
 }
 \examples{
-data(TSSs)
+data(TSSs_reduced)
 
 tsre <- TSSs[1] \%>\%
   tsr_explorer \%>\%

--- a/man/plot_density.Rd
+++ b/man/plot_density.Rd
@@ -81,10 +81,10 @@ and/or group data for plotting. Finally, 'exclude_antisense' removes anti-sense 
   TSRs prior to plotting.
 }
 \examples{
-data(TSSs)
+data(TSSs_reduced)
 annotation <- system.file("extdata", "S288C_Annotation.gtf", package="TSRexploreR")
 
-tsre <- TSSs[1] \%>\%
+tsre <- TSSs \%>\%
   tsr_explorer(genome_annotation=annotation) \%>\%
   format_counts(data_type="tss") \%>\%
   annotate_features(data_type="tss")

--- a/man/plot_detected_features.Rd
+++ b/man/plot_detected_features.Rd
@@ -58,10 +58,10 @@ per gene/transcript. 'data_conditionals' can be used to filter, quantile, order,
 and/or group data for plotting.
 }
 \examples{
-data(TSSs)
+data(TSSs_reduced)
 annotation <- system.file("extdata", "S288C_Annotation.gtf", package="TSRexploreR")
 
-tsre <- TSSs[1] \%>\%
+tsre <- TSSs \%>\%
   tsr_explorer(genome_annotation=annotation) \%>\%
   format_counts(data_type="tss") \%>\%
   annotate_features(data_type="tss")

--- a/man/plot_dinucleotide_frequencies.Rd
+++ b/man/plot_dinucleotide_frequencies.Rd
@@ -65,10 +65,10 @@ For TSSs this can be either dominant per TSR or gene.
   of data.
 }
 \examples{
-data(TSSs)
+data(TSSs_reduced)
 assembly <- system.file("extdata", "S288C_Assembly.fasta", package="TSRexploreR")
 
-tsre <- TSSs[1] \%>\%
+tsre <- TSSs \%>\%
   tsr_explorer(genome_assembly=assembly) \%>\%
   format_counts(data_type="tss")
 

--- a/man/plot_genomic_distribution.Rd
+++ b/man/plot_genomic_distribution.Rd
@@ -61,10 +61,10 @@ If 'return_table' is TRUE, a data.frame containing the underlying data
   for the plot is returned.
 }
 \examples{
-data(TSSs)
+data(TSSs_reduced)
 annotation <- system.file("extdata", "S288C_Annotation.gtf", package="TSRexploreR")
 
-tsre <- TSSs[1] \%>\%
+tsre <- TSSs \%>\%
   tsr_explorer(genome_annotation=annotation) \%>\%
   format_counts(data_type="tss") \%>\%
   annotate_features(data_type="tss")

--- a/man/plot_heatmap.Rd
+++ b/man/plot_heatmap.Rd
@@ -143,10 +143,10 @@ An option to rasterize the heatmaps using ggrastr is provided with the 'rasteriz
   and the DPI (resolution) is controlled by 'raster_dpi'.
 }
 \examples{
-data(TSSs)
+data(TSSs_reduced)
 annotation <- system.file("extdata", "S288C_Annotation.gtf", package="TSRexploreR")
 
-tsre <- TSSs[1] \%>\%
+tsre <- TSSs \%>\%
   tsr_explorer(genome_annotation=annotation) \%>\%
   format_counts(data_type="tss") \%>\%
   annotate_features(data_type="tss")

--- a/man/plot_sequence_colormap.Rd
+++ b/man/plot_sequence_colormap.Rd
@@ -88,10 +88,10 @@ The plot can be rasterized using ggrastr using 'rasterize',
   and the rasterization DPI set using 'raster_dpi'.
 }
 \examples{
-data(TSSs)
+data(TSSs_reduced)
 assembly <- system.file("extdata", "S288C_Assembly.fasta", package="TSRexploreR")
 
-tsre <- TSSs[1] \%>\%
+tsre <- TSSs \%>\%
   tsr_explorer(genome_assembly=assembly) \%>\%
   format_counts(data_type="tss")
 p <- plot_sequence_colormap(tsre, distance=5)

--- a/man/plot_sequence_logo.Rd
+++ b/man/plot_sequence_logo.Rd
@@ -81,10 +81,10 @@ For TSSs this can be either dominant per TSR or gene, and for TSRs
   of data.
 }
 \examples{
-data(TSSs)
+data(TSSs_reduced)
 assembly <- system.file("extdata", "S288C_Assembly.fasta", package="TSRexploreR")
 
-tsre <- TSSs[1] \%>\%
+tsre <- TSSs \%>\%
   tsr_explorer(genome_assembly=assembly) \%>\%
   format_counts(data_type="tss")
 p <- plot_sequence_logo(tsre, distance=5)

--- a/man/plot_threshold_exploration.Rd
+++ b/man/plot_threshold_exploration.Rd
@@ -64,10 +64,10 @@ For STRIPE-seq We have found that a threshold of 3 often provides an appropriate
   transcripts with at least one unique TSS.
 }
 \examples{
-data(TSSs)
+data(TSSs_reduced)
 annotation <- system.file("extdata", "S288C_Annotation.gtf", package="TSRexploreR")
 
-tsre <- TSSs[1] \%>\%
+tsre <- TSSs \%>\%
   tsr_explorer(genome_annotation=annotation) \%>\%
   format_counts(data_type="tss") \%>\%
   annotate_features(data_type="tss")

--- a/man/plot_tsr_metric.Rd
+++ b/man/plot_tsr_metric.Rd
@@ -65,9 +65,9 @@ per gene/transcript. 'data_conditionals' can be used to filter, quantile, order,
 and/or group data for plotting.
 }
 \examples{
-data(TSSs)
+data(TSSs_reduced)
 
-tsre <- TSSs[1] \%>\%
+tsre <- TSSs \%>\%
   tsr_explorer \%>\%
   format_counts(data_type="tss") \%>\%
   tss_clustering(threshold=3)

--- a/man/tsr_export.Rd
+++ b/man/tsr_export.Rd
@@ -47,9 +47,9 @@ If 'diff_tsr' is TRUE, only differential TSRs will be output.
 }
 \examples{
 \dontrun{
-data(TSSs)
+data(TSSs_reduced)
 
-tsre <- TSSs[1] \%>\%
+tsre <- TSSs \%>\%
   tsr_explorer \%>\%
   format_counts(data_type="tss") \%>\%
   tss_clustering(threshold=3)

--- a/man/tsr_import.Rd
+++ b/man/tsr_import.Rd
@@ -38,10 +38,10 @@ first be run up to the 'determineTSR' step.
 }
 \examples{
 \dontrun{
-data(TSSs)
+data(TSSs_reduced)
 
 # Export bed as example data.
-tsre <- TSSs[1] \%>\%
+tsre <- TSSs \%>\%
   tsr_explorer \%>\%
   format_counts(data_type="tss") \%>\%
   tss_clustering(threshold=3)

--- a/man/tsr_metrics.Rd
+++ b/man/tsr_metrics.Rd
@@ -28,9 +28,9 @@ TSRexploreR allows for the calculation of various common TSR shape indicators
 'iqr_lower' and 'iqr_upper' determine the upper and lower quantile bounds for calculation.
 }
 \examples{
-data(TSSs)
+data(TSSs_reduced)
 
-tsre <- TSSs[1] \%>\%
+tsre <- TSSs \%>\%
   tsr_explorer \%>\%
   format_counts(data_type="tss") \%>\%
   tss_clustering(threshold=3) \%>\%

--- a/man/tss_export.Rd
+++ b/man/tss_export.Rd
@@ -51,7 +51,7 @@ save the files to the working directory.
 If 'diff_tss' is TRUE, only differential TSSs will be output.
 }
 \examples{
-data(TSSs)
+data(TSSs_reduced)
 
 \dontrun{
 tsre <- TSSs[1] \%>\%

--- a/man/tss_import.Rd
+++ b/man/tss_import.Rd
@@ -40,10 +40,10 @@ must first be run up to the 'processTSS' step.
 }
 \examples{
 \dontrun{
-data(TSSs)
+data(TSSs_reduced)
 
 # Export bedgraphs as example data.
-tsre <- TSSs[1] \%>\%
+tsre <- TSSs \%>\%
   tsr_explorer \%>\%
   format_counts(data_type="tss")
 tss_export(tsre)


### PR DESCRIPTION
Reduced runtime of many examples by creating a dataset, `TSSs_reduced` that contains the TSSs for only one highly expressed gene.

Fixed an error with matrix creation in a few functions if there was only one sample.