### PR TITLE
fixed typo in data conditioning vignette header

### DIFF
--- a/vignettes/DATA_CONDITIONING.Rmd
+++ b/vignettes/DATA_CONDITIONING.Rmd
@@ -2,7 +2,7 @@
 title: "Data Conditioning"
 output: rmarkdown::html_vignette
 vignette: >
-  %\VignetteIndexEntry{Standard Analysis}
+  %\VignetteIndexEntry{Data Conditioning}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
 ---


### PR DESCRIPTION
Originally forgot to change the vignette name in the data conditioning vignette.