### PR TITLE
fixing plot_heatmap bug

### DIFF
--- a/R/heatmaps.R
+++ b/R/heatmaps.R
@@ -541,7 +541,7 @@ plot_heatmap <- function(
 ) {
 
   ## Change list to data.table if list provided.
-  if (is.list(split_by)) {
+  if (!is(split_by, "data.frame")) {
     split_by <- map(split_by, ~data.table(feature=.x))
     split_by <- rbindlist(split_by, idcol="split_group")
   } else {


### PR DESCRIPTION
Fixed bug with `plot_heatmap` when a data.frame was supplied to `split_by`. This was caused by `is.list` evaluating to TRUE for data.frames.

fixes #151 